### PR TITLE
Fix typo 'abandonned'

### DIFF
--- a/sr_port/wcs_recover.c
+++ b/sr_port/wcs_recover.c
@@ -439,7 +439,7 @@ void wcs_recover(gd_region *reg)
 					wcs_sleep(lcnt);
 				}
 				if (0 == cr->iosb.cond)
-				{	/* if it's abandonned wip_stopped, treat it as a WRT_STRT_PNDNG */
+				{	/* if it's abandoned wip_stopped, treat it as a WRT_STRT_PNDNG */
 					cr->iosb.cond = WRT_STRT_PNDNG;
 					cr->epid = 0;
 					cr->image_count = 0;


### PR DESCRIPTION

Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abandoned', you typed 'abandonned'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
            